### PR TITLE
Added "Title" field, renamed "Site Size" and fixed "Migration Date"

### DIFF
--- a/src/webparts/migrationDashboard/components/SiteInfo/GeneralInfoSection/GeneralInfoSection.tsx
+++ b/src/webparts/migrationDashboard/components/SiteInfo/GeneralInfoSection/GeneralInfoSection.tsx
@@ -168,6 +168,13 @@ export default class GeneralInfoSection extends React.Component<GeneralInfoSecti
             iconName = "FabricFolderLink"
         }
         items.push({
+            key: "Title",
+            name: "Title",
+            value: props.currentSite.Title,
+            note: "",
+            iconName: "BoldT"
+        });
+        items.push({
             key: "SiteUrl",
             name: name,
             value: props.currentSite.SiteUrl,
@@ -183,7 +190,7 @@ export default class GeneralInfoSection extends React.Component<GeneralInfoSecti
         });
         items.push({
             key: "SiteSizeInMB",
-            name: "Site Size",
+            name: "Size",
             value: Measures.formatToDigitalSpace(props.currentSite.SiteSizeInMB),
             note: "",
             iconName: "Database"
@@ -243,7 +250,7 @@ export default class GeneralInfoSection extends React.Component<GeneralInfoSecti
                 <a href={item.value} data-interception="off" target="_blank">{item.value}</a>
             );
         }
-        if (['ScheduledDate', '____'].indexOf(item.key) > -1 && column.key == "Value") {
+        if (['ScheduledDate', '____'].indexOf(item.key) > -1 && column.key == "Value" && item.value) {
             const scheduledMigrationDate = Dates.getUserFriendlyDate(item.value);
             return (
                 <span>{scheduledMigrationDate}</span>


### PR DESCRIPTION
**Problem:**  The title field is not displayed in General Information section. The "Site Size" field should be renamed as "Size" because the data is not always migrated from the site. The "Migration Date" is displayed incorrectly (as Wed Dec 31 1969 19:00:00) if the field is empty.

**Solution:**

- Added "Title" field to GeneralInfoSection.tsx

-  Renamed "Site Size" to "Size" in GeneralInfoSection.tsx

-  Fixed "Migration Date" in GeneralInfoSection.tsx
